### PR TITLE
Do not provide `setup` feature

### DIFF
--- a/test/setup.el
+++ b/test/setup.el
@@ -13,5 +13,4 @@
   (load test-file nil t))
 
 (ert-run-tests-batch-and-exit t)
-(provide 'setup)
 ;;; setup.el ends here


### PR DESCRIPTION
Test files should not `provide` a feature. Providing a feature is only
suitable for libraries that are loaded by other libraries/packages or
by the end-user using `require`.

For `require` to be able to do its job, the library that provides the
feature has to be located on the `load-path`, but test files should
*not* be located on the `load-path` and in this case that isn't the
case.  We are already loading the `test/setup.el` file without relying
on the `load-path`, so you can just drop the `provide` form.

This fixes #2.